### PR TITLE
fix setExposureAndFocusPoint

### DIFF
--- a/lib/src/widgets/camera_picker.dart
+++ b/lib/src/widgets/camera_picker.dart
@@ -1317,6 +1317,7 @@ class CameraPickerState extends State<CameraPicker>
     return Positioned.fill(
       child: GestureDetector(
         onTapUp: (TapUpDetails d) {
+          // Only call exposure point updates when the controller is initialized.
           if (_controller?.value.isInitialized == true) {
             setExposureAndFocusPoint(d, constraints);
           }

--- a/lib/src/widgets/camera_picker.dart
+++ b/lib/src/widgets/camera_picker.dart
@@ -1316,7 +1316,12 @@ class CameraPickerState extends State<CameraPicker>
   ) {
     return Positioned.fill(
       child: GestureDetector(
-        onTapUp: (TapUpDetails d) => setExposureAndFocusPoint(d, constraints),
+        onTapUp: (TapUpDetails d) {
+          if (_controller?.value.isInitialized != true) {
+            return;
+          }
+          setExposureAndFocusPoint(d, constraints);
+        },
         behavior: HitTestBehavior.translucent,
         child: const SizedBox.expand(),
       ),

--- a/lib/src/widgets/camera_picker.dart
+++ b/lib/src/widgets/camera_picker.dart
@@ -1317,10 +1317,9 @@ class CameraPickerState extends State<CameraPicker>
     return Positioned.fill(
       child: GestureDetector(
         onTapUp: (TapUpDetails d) {
-          if (_controller?.value.isInitialized != true) {
-            return;
+          if (_controller?.value.isInitialized == true) {
+            setExposureAndFocusPoint(d, constraints);
           }
-          setExposureAndFocusPoint(d, constraints);
         },
         behavior: HitTestBehavior.translucent,
         child: const SizedBox.expand(),


### PR DESCRIPTION
### Summary

Fix #65. This PR fixes set exposure crashes when switching between cameras by adding a condition when the set is called.

### Step to reproduce
- Double click to switch between cameras
- When switching, tap the screen again, to call the exposure point set.

### Environments
- System version: Android 10
- Package: ^2.6.2
- Flutter SDK: 2.5.3
- Dart SDK: 2.14.0

### Logs
```
E/AndroidRuntime( 5978): java.lang.AssertionError: The cameraBoundaries should be set (using `ExposurePointFeature.setCameraBoundaries(Size)`) before updating the exposure point.
E/AndroidRuntime( 5978): 	at io.flutter.plugins.camera.features.exposurepoint.ExposurePointFeature.buildExposureRectangle(ExposurePointFeature.java:83)
E/AndroidRuntime( 5978): 	at io.flutter.plugins.camera.features.exposurepoint.ExposurePointFeature.setValue(ExposurePointFeature.java:61)
E/AndroidRuntime( 5978): 	at io.flutter.plugins.camera.Camera.setExposurePoint(Camera.java:803)
E/AndroidRuntime( 5978): 	at io.flutter.plugins.camera.MethodCallHandlerImpl.onMethodCall(MethodCallHandlerImpl.java:183)
E/AndroidRuntime( 5978): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:233)
E/AndroidRuntime( 5978): 	at io.flutter.embedding.engine.dart.DartMessenger.handleMessageFromDart(DartMessenger.java:84)
E/AndroidRuntime( 5978): 	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:865)
E/AndroidRuntime( 5978): 	at android.os.MessageQueue.nativePollOnce(Native Method)
E/AndroidRuntime( 5978): 	at android.os.MessageQueue.next(MessageQueue.java:326)
E/AndroidRuntime( 5978): 	at android.os.Looper.loop(Looper.java:160)
E/AndroidRuntime( 5978): 	at android.app.ActivityThread.main(ActivityThread.java:6713)
E/AndroidRuntime( 5978): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime( 5978): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
E/AndroidRuntime( 5978): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:911)
```