### PR TITLE
🐛 Drop initialize when the controller has been already initialized

### DIFF
--- a/lib/src/widgets/camera_picker.dart
+++ b/lib/src/widgets/camera_picker.dart
@@ -460,13 +460,17 @@ class CameraPickerState extends State<CameraPicker>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    final CameraController? c = _controller;
     // App state changed before we got the chance to initialize.
-    if (_controller == null || !controller.value.isInitialized) {
+    if (c == null || !c.value.isInitialized) {
       return;
     }
     if (state == AppLifecycleState.inactive) {
-      controller.dispose();
-    } else if (state == AppLifecycleState.resumed) {
+      c.dispose();
+    } else if (state == AppLifecycleState.resumed && !c.value.isInitialized) {
+      // Drop initialize when the controller has been already initialized.
+      // This will typically resolve the lifecycle issue on iOS when permissions
+      // are requested for the first time.
       initCameras(currentCamera);
     }
   }


### PR DESCRIPTION
This issue could be introduced by https://github.com/flutter/plugins/pull/4140. Currently, the lifecycle notification will be called asynchronous when requesting permissions, which will cause the lifecycle hook to apply duplicate initializations.