### PR TITLE
✨ Introduce `PreviewTransformBuilder`

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -94,29 +94,30 @@ final AssetEntity? entity = await CameraPicker.pickFromCamera(
 
 `CameraPickerConfig` 的成员说明：
 
-| 参数名                          | 类型                              | 描述                                                 | 默认值                                    |
-|------------------------------|---------------------------------|----------------------------------------------------|----------------------------------------|
-| enableRecording              | `bool`                          | 选择器是否可以录像                                          | `false`                                |
-| onlyEnableRecording          | `bool`                          | 选择器是否仅可以录像。只在 `enableRecording` 为 `true` 时有效。      | `false`                                |
-| enableTapRecording           | `bool`                          | 选择器是否可以单击录像。只在 `onlyEnableRecording` 为 `true` 时生效。 | `false`                                |
-| enableAudio                  | `bool`                          | 选择器是否需要录制音频。只在 `enableRecording` 为 `true` 时有效。     | `true`                                 |
-| enableSetExposure            | `bool`                          | 用户是否可以在界面上通过点击设定曝光点                                | `true`                                 |
-| enableExposureControlOnPoint | `bool`                          | 用户是否可以根据已经设置的曝光点调节曝光度                              | `true`                                 |
-| enablePinchToZoom            | `bool`                          | 用户是否可以在界面上双指缩放相机对焦                                 | `true`                                 |
-| enablePullToZoomInRecord     | `bool`                          | 用户是否可以在录制视频时上拉缩放                                   | `true`                                 |
-| shouldDeletePreviewFile      | `bool`                          | 返回页面时是否删除预览文件                                      | `false`                                |
-| shouldAutoPreviewVideo       | `bool`                          | 在预览时是否直接播放视频                                       | `false`                                |
-| maximumRecordingDuration     | `Duration`                      | 录制视频最长时长                                           | `const Duration(seconds: 15)`          |
-| theme                        | `ThemeData?`                    | 选择器的主题                                             | `CameraPicker.themeData(C.themeColor)` |
-| textDelegate                 | `CameraPickerTextDelegate?`     | 控制部件中的文字实现                                         | `DefaultCameraPickerTextDelegate`      |
-| resolutionPreset             | `ResolutionPreset`              | 相机的分辨率预设                                           | `ResolutionPreset.max`                 |
-| cameraQuarterTurns           | `int`                           | 摄像机视图顺时针旋转次数，每次 90 度                               | `0`                                    |
-| imageFormatGroup             | `ImageFormatGroup`              | 输出图像的格式描述                                          | `ImageFormatGroup.unknown`             |
-| preferredLensDirection       | `CameraLensDirection`           | 首次使用相机时首选的镜头方向                                     | `CameraLensDirection.back`             |
-| lockCaptureOrientation       | `DeviceOrientation?`            | 摄像机在拍摄时锁定的旋转角度                                     | null                                   |
-| foregroundBuilder            | `Widget Function(CameraValue)?` | 覆盖在相机预览上方的前景构建                                     | null                                   |
-| onEntitySaving               | `EntitySaveCallback?`           | 在查看器中保存图片时的回调                                      | null                                   |
-| onError                      | `CameraErrorHandler?`           | 拍摄照片过程中的自定义错误处理                                    | null                                   |
+| 参数名                          | 类型                          | 描述                                                 | 默认值                                    |
+|------------------------------|-----------------------------|----------------------------------------------------|----------------------------------------|
+| enableRecording              | `bool`                      | 选择器是否可以录像                                          | `false`                                |
+| onlyEnableRecording          | `bool`                      | 选择器是否仅可以录像。只在 `enableRecording` 为 `true` 时有效。      | `false`                                |
+| enableTapRecording           | `bool`                      | 选择器是否可以单击录像。只在 `onlyEnableRecording` 为 `true` 时生效。 | `false`                                |
+| enableAudio                  | `bool`                      | 选择器是否需要录制音频。只在 `enableRecording` 为 `true` 时有效。     | `true`                                 |
+| enableSetExposure            | `bool`                      | 用户是否可以在界面上通过点击设定曝光点                                | `true`                                 |
+| enableExposureControlOnPoint | `bool`                      | 用户是否可以根据已经设置的曝光点调节曝光度                              | `true`                                 |
+| enablePinchToZoom            | `bool`                      | 用户是否可以在界面上双指缩放相机对焦                                 | `true`                                 |
+| enablePullToZoomInRecord     | `bool`                      | 用户是否可以在录制视频时上拉缩放                                   | `true`                                 |
+| shouldDeletePreviewFile      | `bool`                      | 返回页面时是否删除预览文件                                      | `false`                                |
+| shouldAutoPreviewVideo       | `bool`                      | 在预览时是否直接播放视频                                       | `false`                                |
+| maximumRecordingDuration     | `Duration`                  | 录制视频最长时长                                           | `const Duration(seconds: 15)`          |
+| theme                        | `ThemeData?`                | 选择器的主题                                             | `CameraPicker.themeData(C.themeColor)` |
+| textDelegate                 | `CameraPickerTextDelegate?` | 控制部件中的文字实现                                         | `DefaultCameraPickerTextDelegate`      |
+| resolutionPreset             | `ResolutionPreset`          | 相机的分辨率预设                                           | `ResolutionPreset.max`                 |
+| cameraQuarterTurns           | `int`                       | 摄像机视图顺时针旋转次数，每次 90 度                               | `0`                                    |
+| imageFormatGroup             | `ImageFormatGroup`          | 输出图像的格式描述                                          | `ImageFormatGroup.unknown`             |
+| preferredLensDirection       | `CameraLensDirection`       | 首次使用相机时首选的镜头方向                                     | `CameraLensDirection.back`             |
+| lockCaptureOrientation       | `DeviceOrientation?`        | 摄像机在拍摄时锁定的旋转角度                                     | null                                   |
+| foregroundBuilder            | `ForegroundBuilder?`        | 覆盖在相机预览上方的前景构建                                     | null                                   |
+| previewTransformBuilder      | `PreviewTransformBuilder?`  | 对相机预览做变换的构建                                        | null                                   |
+| onEntitySaving               | `EntitySaveCallback?`       | 在查看器中保存图片时的回调                                      | null                                   |
+| onError                      | `CameraErrorHandler?`       | 拍摄照片过程中的自定义错误处理                                    | null                                   |
 
 ## 常见问题 💭
 

--- a/README.md
+++ b/README.md
@@ -79,29 +79,30 @@ final AssetEntity? entity = await CameraPicker.pickFromCamera(
 
 Fields in `CameraPickerConfig`:
 
-| Name                         | Type                            | Description                                                                                           | Default Value                          |
-|------------------------------|---------------------------------|-------------------------------------------------------------------------------------------------------|----------------------------------------|
-| enableRecording              | `bool`                          | Whether the picker can record video.                                                                  | `false`                                |
-| onlyEnableRecording          | `bool`                          | Whether the picker can only record video. Only available when `enableRecording` is `true `.           | `false`                                |
-| enableTapRecording           | `bool`                          | Whether allow the record can start with single tap. Only available when `enableRecording` is `true `. | `false`                                |
-| enableAudio                  | `bool`                          | Whether Whether the picker should record audio. Only available with recording.                        | `true`                                 |
-| enableSetExposure            | `bool`                          | Whether users can set the exposure point by tapping.                                                  | `true`                                 |
-| enableExposureControlOnPoint | `bool`                          | Whether users can adjust exposure according to the set point.                                         | `true`                                 |
-| enablePinchToZoom            | `bool`                          | Whether users can zoom the camera by pinch.                                                           | `true`                                 |
-| enablePullToZoomInRecord     | `bool`                          | Whether users can zoom by pulling up when recording video.                                            | `true`                                 |
-| shouldDeletePreviewFile      | `bool`                          | Whether the preview file will be delete when pop.                                                     | `false`                                |
-| shouldAutoPreviewVideo       | `bool`                          | Whether the video should be played instantly in the preview.                                          | `false`                                |
-| maximumRecordingDuration     | `Duration`                      | The maximum duration of the video recording process.                                                  | `const Duration(seconds: 15)`          |
-| theme                        | `ThemeData?`                    | Theme data for the picker.                                                                            | `CameraPicker.themeData(C.themeColor)` |
-| textDelegate                 | `CameraPickerTextDelegate?`     | Text delegate that controls text in widgets.                                                          | `DefaultCameraPickerTextDelegate`      |
-| resolutionPreset             | `ResolutionPreset`              | Present resolution for the camera.                                                                    | `ResolutionPreset.max`                 |
-| cameraQuarterTurns           | `int`                           | The number of clockwise quarter turns the camera view should be rotated.                              | `0`                                    |
-| imageFormatGroup             | `ImageFormatGroup`              | Describes the output of the raw image format.                                                         | `ImageFormatGroup.unknown`             |
-| preferredLensDirection       | `CameraLensDirection`           | Which lens direction is preferred when first using the camera.                                        | `CameraLensDirection.back`             |
-| lockCaptureOrientation       | `DeviceOrientation?`            | Whether the camera should be locked to the specific orientation during captures.                      | null                                   |
-| foregroundBuilder            | `Widget Function(CameraValue)?` | The foreground widget builder which will cover the whole camera preview.                              | null                                   |
-| onEntitySaving               | `EntitySaveCallback?`           | The callback type define for saving entity in the viewer.                                             | null                                   |
-| onError                      | `CameraErrorHandler?`           | The error handler when any error occurred during the picking process.                                 | null                                   |
+| Name                         | Type                        | Description                                                                                           | Default Value                          |
+|------------------------------|-----------------------------|-------------------------------------------------------------------------------------------------------|----------------------------------------|
+| enableRecording              | `bool`                      | Whether the picker can record video.                                                                  | `false`                                |
+| onlyEnableRecording          | `bool`                      | Whether the picker can only record video. Only available when `enableRecording` is `true `.           | `false`                                |
+| enableTapRecording           | `bool`                      | Whether allow the record can start with single tap. Only available when `enableRecording` is `true `. | `false`                                |
+| enableAudio                  | `bool`                      | Whether Whether the picker should record audio. Only available with recording.                        | `true`                                 |
+| enableSetExposure            | `bool`                      | Whether users can set the exposure point by tapping.                                                  | `true`                                 |
+| enableExposureControlOnPoint | `bool`                      | Whether users can adjust exposure according to the set point.                                         | `true`                                 |
+| enablePinchToZoom            | `bool`                      | Whether users can zoom the camera by pinch.                                                           | `true`                                 |
+| enablePullToZoomInRecord     | `bool`                      | Whether users can zoom by pulling up when recording video.                                            | `true`                                 |
+| shouldDeletePreviewFile      | `bool`                      | Whether the preview file will be delete when pop.                                                     | `false`                                |
+| shouldAutoPreviewVideo       | `bool`                      | Whether the video should be played instantly in the preview.                                          | `false`                                |
+| maximumRecordingDuration     | `Duration`                  | The maximum duration of the video recording process.                                                  | `const Duration(seconds: 15)`          |
+| theme                        | `ThemeData?`                | Theme data for the picker.                                                                            | `CameraPicker.themeData(C.themeColor)` |
+| textDelegate                 | `CameraPickerTextDelegate?` | Text delegate that controls text in widgets.                                                          | `DefaultCameraPickerTextDelegate`      |
+| resolutionPreset             | `ResolutionPreset`          | Present resolution for the camera.                                                                    | `ResolutionPreset.max`                 |
+| cameraQuarterTurns           | `int`                       | The number of clockwise quarter turns the camera view should be rotated.                              | `0`                                    |
+| imageFormatGroup             | `ImageFormatGroup`          | Describes the output of the raw image format.                                                         | `ImageFormatGroup.unknown`             |
+| preferredLensDirection       | `CameraLensDirection`       | Which lens direction is preferred when first using the camera.                                        | `CameraLensDirection.back`             |
+| lockCaptureOrientation       | `DeviceOrientation?`        | Whether the camera should be locked to the specific orientation during captures.                      | null                                   |
+| foregroundBuilder            | `ForegroundBuilder?`        | The foreground widget builder which will cover the whole camera preview.                              | null                                   |
+| previewTransformBuilder      | `PreviewTransformBuilder?`  | The widget builder which will transform the camera preview.                                           | null                                   |
+| onEntitySaving               | `EntitySaveCallback?`       | The callback type define for saving entity in the viewer.                                             | null                                   |
+| onError                      | `CameraErrorHandler?`       | The error handler when any error occurred during the picking process.                                 | null                                   |
 
 ## Frequently asked question 💭
 

--- a/lib/src/constants/config.dart
+++ b/lib/src/constants/config.dart
@@ -34,6 +34,7 @@ class CameraPickerConfig {
     this.preferredLensDirection = CameraLensDirection.back,
     this.lockCaptureOrientation,
     this.foregroundBuilder,
+    this.previewTransformBuilder,
     this.onEntitySaving,
     this.onError,
   }) : assert(
@@ -120,9 +121,11 @@ class CameraPickerConfig {
   /// 首次使用相机时首选的镜头方向，通常是前置或后置。
   final CameraLensDirection preferredLensDirection;
 
-  /// The foreground widget builder which will cover the whole camera preview.
-  /// 覆盖在相机预览上方的前景构建
-  final Widget Function(CameraValue)? foregroundBuilder;
+  /// {@macro wechat_camera_picker.ForegroundBuilder}
+  final ForegroundBuilder? foregroundBuilder;
+
+  /// {@macro wechat_camera_picker.PreviewTransformBuilder}
+  final PreviewTransformBuilder? previewTransformBuilder;
 
   /// Whether the camera should be locked to the specific orientation
   /// during captures.

--- a/lib/src/internals/type_defs.dart
+++ b/lib/src/internals/type_defs.dart
@@ -2,10 +2,11 @@
 /// [Author] Alex (https://github.com/AlexV525)
 /// [Date] 2021/9/30 17:04
 ///
-import 'dart:async';
-import 'dart:io';
+import 'dart:async' show FutureOr;
+import 'dart:io' show File;
 
-import 'package:flutter/widgets.dart';
+import 'package:camera/camera.dart' show CameraController, CameraValue;
+import 'package:flutter/widgets.dart' show BuildContext, Widget;
 
 import '../internals/enums.dart';
 
@@ -37,4 +38,23 @@ typedef EntitySaveCallback = FutureOr<dynamic> Function({
 typedef CameraErrorHandler = void Function(
   Object error,
   StackTrace? stackTrace,
+);
+
+/// {@template wechat_camera_picker.ForegroundBuilder}
+/// Build the foreground/overlay widget with the given [cameraValue].
+/// 根据给定的 [cameraValue] 构建自定义的前景 widget
+/// {@endtemplate}
+typedef ForegroundBuilder = Widget Function(
+  BuildContext context,
+  CameraValue cameraValue,
+);
+
+/// {@template wechat_camera_picker.PreviewTransformBuilder}
+/// Build the transformed widget with the given [controller].
+/// 根据给定的 [controller] 构建自定义的变换 widget
+/// {@endtemplate}
+typedef PreviewTransformBuilder = Widget? Function(
+  BuildContext context,
+  CameraController controller,
+  Widget child,
 );

--- a/lib/src/widgets/camera_picker.dart
+++ b/lib/src/widgets/camera_picker.dart
@@ -1274,14 +1274,13 @@ class CameraPickerState extends State<CameraPicker>
       ),
     );
 
-    // Flip the preview if the user is using a front camera to match the result.
-    if (currentCamera.lensDirection == CameraLensDirection.front) {
-      _preview = Transform(
-        transform: Matrix4.rotationY(math.pi),
-        alignment: Alignment.center,
-        child: _preview,
-      );
-    }
+    // Make a transformed widget if it's defined.
+    final Widget? _transformedWidget = config.previewTransformBuilder?.call(
+      context,
+      controller,
+      _preview,
+    );
+    _preview = _transformedWidget ?? _preview;
 
     _preview = RotatedBox(
       quarterTurns: -config.cameraQuarterTurns,
@@ -1328,7 +1327,7 @@ class CameraPickerState extends State<CameraPicker>
             ),
           ),
           if (config.foregroundBuilder != null)
-            Positioned.fill(child: config.foregroundBuilder!(value)),
+            Positioned.fill(child: config.foregroundBuilder!(context, value)),
         ],
       ),
     );


### PR DESCRIPTION
Partially resolves #75.

Allow users to build a transformed widget for the preview according to the given `CameraController`.

Breaking changes:
- `foregroundBuilder`'s signature has been updated.