### PR TITLE
♻️ Make `XFileCapturedCallback` return a boolean result

### DIFF
--- a/lib/src/constants/type_defs.dart
+++ b/lib/src/constants/type_defs.dart
@@ -67,10 +67,10 @@ typedef PreviewTransformBuilder = Widget? Function(
 /// 如果在回调中已经进行了处理，请返回 `true`。
 ///
 /// ### Notice about the implementation
-///  * After the callback is implemented, the default viewer page 
-///    will not be pushed anymore.
+///  * After the callback is implemented and returned `true`,
+///    the default viewer page will not be presented anymore.
 ///
 /// ### 在实现时需要注意
-///  * 实现该方法后，默认的的预览页面不会再出现。
+///  * 实现该方法后且返回 `true` 后，默认的预览页面不会再出现。
 /// {@endtemplate}
 typedef XFileCapturedCallback = bool Function(XFile, CameraPickerViewType);

--- a/lib/src/constants/type_defs.dart
+++ b/lib/src/constants/type_defs.dart
@@ -63,6 +63,9 @@ typedef PreviewTransformBuilder = Widget? Function(
 /// The callback type definition when the XFile is captured by the camera.
 /// 拍摄文件生成后的回调
 ///
+/// Return `true` if it has handled arguments.
+/// 如果在回调中已经进行了处理，请返回 `true`。
+///
 /// ### Notice about the implementation
 ///  * After the callback is implemented, the default viewer page 
 ///    will not be pushed anymore.
@@ -70,4 +73,4 @@ typedef PreviewTransformBuilder = Widget? Function(
 /// ### 在实现时需要注意
 ///  * 实现该方法后，默认的的预览页面不会再出现。
 /// {@endtemplate}
-typedef XFileCapturedCallback = void Function(XFile, CameraPickerViewType);
+typedef XFileCapturedCallback = bool Function(XFile, CameraPickerViewType);

--- a/lib/src/constants/type_defs.dart
+++ b/lib/src/constants/type_defs.dart
@@ -71,6 +71,6 @@ typedef PreviewTransformBuilder = Widget? Function(
 ///    the default viewer page will not be presented anymore.
 ///
 /// ### 在实现时需要注意
-///  * 实现该方法后且返回 `true` 后，默认的预览页面不会再出现。
+///  * 实现了该方法且返回 `true` 后，默认的预览页面不会再出现。
 /// {@endtemplate}
 typedef XFileCapturedCallback = bool Function(XFile, CameraPickerViewType);

--- a/lib/src/widgets/camera_picker.dart
+++ b/lib/src/widgets/camera_picker.dart
@@ -646,7 +646,7 @@ class CameraPickerState extends State<CameraPicker>
       return;
     }
     try {
-      final XFile _file = await controller.takePicture();
+      final XFile file = await controller.takePicture();
       // Delay disposing the controller to hold the preview.
       Future<void>.delayed(const Duration(milliseconds: 500), () {
         _controller?.dispose();
@@ -654,12 +654,15 @@ class CameraPickerState extends State<CameraPicker>
           _controller = null;
         });
       });
-      if (config.onXFileCaptured != null) {
-        config.onXFileCaptured!(_file, CameraPickerViewType.image);
+      final bool? isCapturedFileHandled = config.onXFileCaptured?.call(
+        file,
+        CameraPickerViewType.image,
+      );
+      if (isCapturedFileHandled == true) {
         return;
       }
       final AssetEntity? entity = await _pushToViewer(
-        file: _file,
+        file: file,
         viewType: CameraPickerViewType.image,
       );
       if (entity != null) {
@@ -747,8 +750,11 @@ class CameraPickerState extends State<CameraPicker>
     if (controller.value.isRecordingVideo) {
       try {
         final XFile file = await controller.stopVideoRecording();
-        if (config.onXFileCaptured != null) {
-          config.onXFileCaptured!(file, CameraPickerViewType.video);
+        final bool? isCapturedFileHandled = config.onXFileCaptured?.call(
+          file,
+          CameraPickerViewType.video,
+        );
+        if (isCapturedFileHandled == true) {
           return;
         }
         final AssetEntity? entity = await _pushToViewer(


### PR DESCRIPTION
`XFileCapturedCallback` provides the ability to handle the produced file. However, it cannot handle case-by-case when the file or the preview type is different.

By updating the signature, users can return a boolean result when arguments are truly handled by the callback.

/cc @ZhuBoao 