### PR TITLE
🚑️ Fix the too early `widget` access in `CameraPickerState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ that can be found in the LICENSE file. -->
 
 # Changelog
 
+## 3.5.0+1
+
+### Fixes
+
+- Fix the too early `widget` access in `CameraPickerState`. (#124)
+
 ## 3.5.0
 
 ### New features

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wechat_camera_picker_demo
 description: A new Flutter project.
-version: 3.5.0+14
+version: 3.5.0+15
 publish_to: none
 
 environment:

--- a/lib/src/states/camera_picker_state.dart
+++ b/lib/src/states/camera_picker_state.dart
@@ -31,11 +31,6 @@ const Duration _kDuration = Duration(milliseconds: 300);
 
 class CameraPickerState extends State<CameraPicker>
     with WidgetsBindingObserver {
-  CameraPickerState({Locale? locale}) {
-    Constants.textDelegate = widget.pickerConfig.textDelegate ??
-        cameraPickerTextDelegateFromLocale(locale);
-  }
-
   /// The [Duration] for record detection. (200ms)
   /// 检测是否开始录制的时长 (200毫秒)
   final Duration recordDetectDuration = const Duration(milliseconds: 200);
@@ -164,6 +159,8 @@ class CameraPickerState extends State<CameraPicker>
   void initState() {
     super.initState();
     ambiguate(WidgetsBinding.instance)?.addObserver(this);
+    Constants.textDelegate = widget.pickerConfig.textDelegate ??
+        cameraPickerTextDelegateFromLocale(widget.locale);
 
     // TODO(Alex): Currently hide status bar will cause the viewport shaking on Android.
     /// Hide system status bar automatically when the platform is not Android.

--- a/lib/src/widgets/camera_picker.dart
+++ b/lib/src/widgets/camera_picker.dart
@@ -111,5 +111,5 @@ class CameraPicker extends StatefulWidget {
   @override
   CameraPickerState createState() =>
       // ignore: no_logic_in_create_state
-      createPickerState?.call() ?? CameraPickerState(locale: locale);
+      createPickerState?.call() ?? CameraPickerState();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wechat_camera_picker
 description: A camera picker which is an extension to wechat_assets_picker, but can be run separately.
-version: 3.5.0
+version: 3.5.0+1
 homepage: https://github.com/fluttercandies/flutter_wechat_camera_picker
 
 environment:


### PR DESCRIPTION
Also, the `locale` is redundant since it can be accessed by `widget.locale`.