### PR TITLE
🐛 Correct sizes when using `cameraQuarterTurns`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ that can be found in the LICENSE file. -->
 
 # Changelog
 
+## 3.6.5
+
+### Fixes
+
+- Correct sizes when using `cameraQuarterTurns`. (#149)
+
 ## 3.6.4
 
 ### Improvements

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wechat_camera_picker_demo
 description: A new Flutter project.
-version: 3.6.4+20
+version: 3.6.5+21
 publish_to: none
 
 environment:

--- a/lib/src/states/camera_picker_state.dart
+++ b/lib/src/states/camera_picker_state.dart
@@ -1180,7 +1180,7 @@ class CameraPickerState extends State<CameraPicker>
       // Only call exposure point updates when the controller is initialized.
       if (innerController?.value.isInitialized ?? false) {
         Feedback.forTap(context);
-        setExposureAndFocusPoint(d.globalPosition, constraints);
+        setExposureAndFocusPoint(d.localPosition, constraints);
       }
     }
 
@@ -1340,6 +1340,7 @@ class CameraPickerState extends State<CameraPicker>
 
   @override
   Widget build(BuildContext context) {
+    final MediaQueryData mq = MediaQuery.of(context);
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle.light,
       child: Theme(
@@ -1348,7 +1349,14 @@ class CameraPickerState extends State<CameraPicker>
           color: Colors.black,
           child: RotatedBox(
             quarterTurns: pickerConfig.cameraQuarterTurns,
-            child: buildBody(context),
+            child: MediaQuery(
+              data: mq.copyWith(
+                size: pickerConfig.cameraQuarterTurns.isOdd
+                    ? mq.size.flipped
+                    : mq.size,
+              ),
+              child: Builder(builder: buildBody),
+            ),
           ),
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wechat_camera_picker
 description: A camera picker based on WeChat's UI which is a separate runnable extension to wechat_assets_picker.
 repository: https://github.com/fluttercandies/flutter_wechat_camera_picker
-version: 3.6.4
+version: 3.6.5
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Fix #148

- Use `localPosition` for the exposure widget to get the correct offset when the interface was turned.
- Generate a flipped size of `MediaQueryData` conditionally in order to correct the actual size of the frame.