### PR TITLE
Proposed solution to #154 [BUG] iOS front camera flash can be set ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ that can be found in the LICENSE file. -->
 
 # Changelog
 
+## 3.7.0
+
+### Improvements
+
+- Allow flash modes failed to switch and can move on to next when switching. (#156)
+
 ## 3.6.5
 
 ### Fixes

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wechat_camera_picker_demo
 description: A new Flutter project.
-version: 3.6.5+21
+version: 3.7.0+22
 publish_to: none
 
 environment:

--- a/lib/src/states/camera_picker_state.dart
+++ b/lib/src/states/camera_picker_state.dart
@@ -369,9 +369,14 @@ class CameraPickerState extends State<CameraPicker>
 
   /// The method to switch between flash modes.
   /// 切换闪光灯模式的方法
-  Future<void> switchFlashesMode() async {
+  Future<void> switchFlashesMode(
+      {
+        FlashMode? currentFlashMode,
+        int infiniteLoopControl = 5,
+      }
+      ) async {
     final FlashMode newFlashMode;
-    switch (controller.value.flashMode) {
+    switch (currentFlashMode ?? controller.value.flashMode) {
       case FlashMode.off:
         newFlashMode = FlashMode.auto;
         break;
@@ -388,6 +393,13 @@ class CameraPickerState extends State<CameraPicker>
     try {
       await controller.setFlashMode(newFlashMode);
     } catch (e, s) {
+      // forcing unsupported flash mode push
+      if (infiniteLoopControl > 0) {
+        await switchFlashesMode(
+          currentFlashMode: newFlashMode,
+          infiniteLoopControl: infiniteLoopControl - 1,
+        );
+      }
       handleErrorWithHandler(e, pickerConfig.onError, s: s);
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: wechat_camera_picker
 description: A camera picker based on WeChat's UI which is a separate runnable extension to wechat_assets_picker.
 repository: https://github.com/fluttercandies/flutter_wechat_camera_picker
-version: 3.6.5
+version: 3.7.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
… from auto to on but not further

This is a proposed solution to #154 [BUG] iOS front camera flash can be set from auto to on but not further .

This solves the unsupported flash modes exception by falling back on the next mode with an infinite loop prevention control (just in case no flash mode is supported).