### PR TITLE
Proposed solution for #155 [BUG] iOS camera preview crashes when switching app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ that can be found in the LICENSE file. -->
 
 - Allow flash modes failed to switch and can move on to next when switching. (#156)
 
+### Fixes
+
+- Fix lifecycle integrations with the camera preview. (#157)
+
 ## 3.6.5
 
 ### Fixes

--- a/lib/src/states/camera_picker_state.dart
+++ b/lib/src/states/camera_picker_state.dart
@@ -199,18 +199,14 @@ class CameraPickerState extends State<CameraPicker>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     final CameraController? c = innerController;
-    if (c == null || !c.value.isInitialized) {
-      if (state == AppLifecycleState.resumed) {
-        initCameras(currentCamera);
-      }
+    if (state == AppLifecycleState.resumed) {
+      initCameras(currentCamera);
+    } else if (c == null || !c.value.isInitialized) {
       // App state changed before we got the chance to initialize.
       return;
-    }
-    if (state == AppLifecycleState.inactive) {
+    } else if (state == AppLifecycleState.inactive) {
       c.dispose();
       innerController = null;
-    } else if (state == AppLifecycleState.resumed) {
-      initCameras(currentCamera);
     }
   }
 

--- a/lib/src/states/camera_picker_state.dart
+++ b/lib/src/states/camera_picker_state.dart
@@ -199,11 +199,11 @@ class CameraPickerState extends State<CameraPicker>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     final CameraController? c = innerController;
-    if (c == null && state == AppLifecycleState.resumed) {
-      initCameras(currentCamera);
-    }
-    // App state changed before we got the chance to initialize.
     if (c == null || !c.value.isInitialized) {
+      if (state == AppLifecycleState.resumed) {
+        initCameras(currentCamera);
+      }
+      // App state changed before we got the chance to initialize.
       return;
     }
     if (state == AppLifecycleState.inactive) {

--- a/lib/src/states/camera_picker_state.dart
+++ b/lib/src/states/camera_picker_state.dart
@@ -192,12 +192,16 @@ class CameraPickerState extends State<CameraPicker>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     final CameraController? c = innerController;
+    if (c == null && state == AppLifecycleState.resumed) {
+      initCameras(currentCamera);
+    }
     // App state changed before we got the chance to initialize.
     if (c == null || !c.value.isInitialized) {
       return;
     }
     if (state == AppLifecycleState.inactive) {
       c.dispose();
+      innerController = null;
     } else if (state == AppLifecycleState.resumed) {
       initCameras(currentCamera);
     }


### PR DESCRIPTION
This proposed solution solved my issue on iPhone SE 2020 through near-production installation through test-flight.