### PR TITLE
Implements feature to influence position of camera controls in horizontal mode

### DIFF
--- a/lib/src/constants/config.dart
+++ b/lib/src/constants/config.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../delegates/camera_picker_text_delegate.dart';
+import 'enums.dart';
 import 'type_defs.dart';
 
 /// {@template wechat_camera_picker.CameraPickerConfig}
@@ -35,6 +36,7 @@ class CameraPickerConfig {
     this.imageFormatGroup = ImageFormatGroup.unknown,
     this.preferredLensDirection = CameraLensDirection.back,
     this.preferredFlashMode = FlashMode.off,
+    this.dominantHand = DominantHand.left,
     this.lockCaptureOrientation,
     this.foregroundBuilder,
     this.previewTransformBuilder,
@@ -152,6 +154,10 @@ class CameraPickerConfig {
   /// typically with the auto mode.
   /// 首次使用相机时首选的闪光灯，通常是自动模式。
   final FlashMode preferredFlashMode;
+
+  /// Influences placement of camera control widgets in horizontal mode.
+  /// 影响水平模式下相机控制部件的放置。
+  final DominantHand dominantHand;
 
   /// {@macro wechat_camera_picker.EntitySaveCallback}
   final EntitySaveCallback? onEntitySaving;

--- a/lib/src/constants/enums.dart
+++ b/lib/src/constants/enums.dart
@@ -5,3 +5,5 @@
 /// Two types for the viewer: image and video.
 /// 两种预览类型：图片和视频
 enum CameraPickerViewType { image, video }
+
+enum DominantHand { left, right }

--- a/lib/src/states/camera_picker_state.dart
+++ b/lib/src/states/camera_picker_state.dart
@@ -1635,6 +1635,14 @@ class CameraPickerState extends State<CameraPicker>
     );
   }
 
+  TextDirection determineTextDirection(Enum orientation, DominantHand hand) {
+    if (orientation == DeviceOrientation.landscapeRight) {
+      return hand == DominantHand.left ? TextDirection.rtl : TextDirection.ltr;
+    } else {
+      return hand == DominantHand.right ? TextDirection.ltr : TextDirection.rtl;
+    }
+  }
+
   Widget buildForegroundBody(
     BuildContext context,
     BoxConstraints constraints,
@@ -1647,9 +1655,8 @@ class CameraPickerState extends State<CameraPicker>
         padding: const EdgeInsets.only(bottom: 20),
         child: Flex(
           direction: isPortrait ? Axis.vertical : Axis.horizontal,
-          textDirection: orientation == DeviceOrientation.landscapeRight
-              ? TextDirection.rtl
-              : TextDirection.ltr,
+          textDirection:
+              determineTextDirection(orientation, pickerConfig.dominantHand),
           verticalDirection: orientation == DeviceOrientation.portraitDown
               ? VerticalDirection.up
               : VerticalDirection.down,


### PR DESCRIPTION
**Tested using**
- iPad 12,9" (iOS 16.4)
- Flutter 3.13.7
- camera lib 0.10.5+5

**Summary**
This PR introduces an option for developers to align camera control widgets either to the left or right in horizontal mode for the `flutter_wechat_camera_picker`.

**Description**
At present, the `flutter_wechat_camera_picker` positions its camera control widgets to the left when operated in horizontal mode. This alignment contrasts with the native iOS camera preview view, which aligns its controls to the right. It's possible that this leftward alignment might be the default for most WeChat-related components. I personally favor the native iOS style, with the controls on the right. Previously, the only workaround was to set `cameraQuarterTurns` to `2`, which would align the controls to the right but in an upside-down manner. This PR offers a more streamlined solution, enabling developers to decide the preferred alignment for the camera controls.