### PR TITLE
✨Add custom onPicked callback when asset entity is generated

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -206,6 +206,7 @@ final AssetEntity? entity = await CameraPicker.pickFromCamera(
 | onError                       | `CameraErrorHandler?`       | 拍摄照片过程中的自定义错误处理                                    | null                                       |
 | onXFileCaptured               | `XFileCapturedCallback?`    | 拍摄文件生成后的回调                                         | null                                       |
 | onMinimumRecordDurationNotMet | `VoidCallback?`             | 录制时长未达到最小时长时的回调方法                                  | null                                       |
+| onPicked                      | `Function(AssetEntity)?`    | 拍照或录像确认时的回调方法。                                       | null                                       |
 
 ### 使用自定义的 `State`
 

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -206,7 +206,7 @@ final AssetEntity? entity = await CameraPicker.pickFromCamera(
 | onError                       | `CameraErrorHandler?`       | 拍摄照片过程中的自定义错误处理                                    | null                                       |
 | onXFileCaptured               | `XFileCapturedCallback?`    | 拍摄文件生成后的回调                                         | null                                       |
 | onMinimumRecordDurationNotMet | `VoidCallback?`             | 录制时长未达到最小时长时的回调方法                                  | null                                       |
-| onPicked                      | `Function(AssetEntity)?`    | 拍照或录像确认时的回调方法。                                       | null                                       |
+| onPickConfirmed                      | `void Function(AssetEntity)?`    | 拍照或录像确认时的回调方法。                                       | null                                       |
 
 ### 使用自定义的 `State`
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Fields in `CameraPickerConfig`:
 | onError                       | `CameraErrorHandler?`       | The error handler when any error occurred during the picking process.                                 | null                                       |
 | onXFileCaptured               | `XFileCapturedCallback?`    | The callback type definition when the XFile is captured by the camera.                                | null                                       |
 | onMinimumRecordDurationNotMet | `VoidCallback?`             | The callback when the recording is not met the minimum recording duration.                            | null                                       |
-| onPicked                      | `Function(AssetEntity)?`    | The callback when picture is taken or video is confirmed.                                             | null                                       |
+| onPickConfirmed                      | `void Function(AssetEntity)?`    | The callback when picture is taken or video is confirmed.                                             | null                                       |
 
 ### Using custom `State`s
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Fields in `CameraPickerConfig`:
 | onError                       | `CameraErrorHandler?`       | The error handler when any error occurred during the picking process.                                 | null                                       |
 | onXFileCaptured               | `XFileCapturedCallback?`    | The callback type definition when the XFile is captured by the camera.                                | null                                       |
 | onMinimumRecordDurationNotMet | `VoidCallback?`             | The callback when the recording is not met the minimum recording duration.                            | null                                       |
+| onPicked                      | `Function(AssetEntity)?`    | The callback when picture is taken or video is confirmed.                                             | null                                       |
 
 ### Using custom `State`s
 

--- a/lib/src/constants/config.dart
+++ b/lib/src/constants/config.dart
@@ -168,7 +168,7 @@ final class CameraPickerConfig {
   /// 录制时长未达到最小时长时的回调方法。
   final VoidCallback? onMinimumRecordDurationNotMet;
 
-  /// The callback when picture is taken or video is recorded.
-  /// 拍照或录像完成时的回调方法。
+  /// The callback when picture is taken or video is confirmed.
+  /// 拍照或录像确认时的回调方法。
   final Function(AssetEntity)? onPicked;
 }

--- a/lib/src/constants/config.dart
+++ b/lib/src/constants/config.dart
@@ -5,6 +5,7 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:photo_manager/photo_manager.dart';
 
 import '../delegates/camera_picker_text_delegate.dart';
 import 'type_defs.dart';
@@ -42,6 +43,7 @@ final class CameraPickerConfig {
     this.onError,
     this.onXFileCaptured,
     this.onMinimumRecordDurationNotMet,
+    this.onPicked,
   }) : assert(
           enableRecording == true || onlyEnableRecording != true,
           'Recording mode error.',
@@ -165,4 +167,8 @@ final class CameraPickerConfig {
   /// The callback when the recording is not met the minimum recording duration.
   /// 录制时长未达到最小时长时的回调方法。
   final VoidCallback? onMinimumRecordDurationNotMet;
+
+  /// The callback when picture is taken or video is recorded.
+  /// 拍照或录像完成时的回调方法。
+  final Function(AssetEntity)? onPicked;
 }

--- a/lib/src/constants/config.dart
+++ b/lib/src/constants/config.dart
@@ -168,7 +168,7 @@ final class CameraPickerConfig {
   /// 录制时长未达到最小时长时的回调方法。
   final VoidCallback? onMinimumRecordDurationNotMet;
 
-  /// The callback when picture is taken or video is confirmed.
+  /// The callback when the picture or the video is confirmed as picked.
   /// 拍照或录像确认时的回调方法。
   final void Function(AssetEntity)? onPickConfirmed;
 }

--- a/lib/src/constants/config.dart
+++ b/lib/src/constants/config.dart
@@ -43,7 +43,7 @@ final class CameraPickerConfig {
     this.onError,
     this.onXFileCaptured,
     this.onMinimumRecordDurationNotMet,
-    this.onPicked,
+    this.onPickConfirmed,
   }) : assert(
           enableRecording == true || onlyEnableRecording != true,
           'Recording mode error.',
@@ -170,5 +170,5 @@ final class CameraPickerConfig {
 
   /// The callback when picture is taken or video is confirmed.
   /// 拍照或录像确认时的回调方法。
-  final Function(AssetEntity)? onPicked;
+  final void Function(AssetEntity)? onPickConfirmed;
 }

--- a/lib/src/states/camera_picker_state.dart
+++ b/lib/src/states/camera_picker_state.dart
@@ -926,9 +926,9 @@ class CameraPickerState extends State<CameraPicker>
         viewType: CameraPickerViewType.image,
       );
       if (entity != null) {
-        if (pickerConfig.onPicked case final onPicked?) {
+        if (pickerConfig.onPickConfirmed case final onPickConfirmed?) {
           await controller.resumePreview();
-          onPicked(entity);
+          onPickConfirmed(entity);
         } else {
           Navigator.of(context).pop(entity);
         }
@@ -1061,9 +1061,9 @@ class CameraPickerState extends State<CameraPicker>
         viewType: CameraPickerViewType.video,
       );
       if (entity != null) {
-        if (pickerConfig.onPicked case final onPicked?) {
+        if (pickerConfig.onPickConfirmed case final onPickConfirmed?) {
           await controller.resumePreview();
-          onPicked(entity);
+          onPickConfirmed(entity);
         } else {
           Navigator.of(context).pop(entity);
         }

--- a/lib/src/states/camera_picker_state.dart
+++ b/lib/src/states/camera_picker_state.dart
@@ -17,10 +17,10 @@ import 'package:sensors_plus/sensors_plus.dart';
 import 'package:wechat_picker_library/wechat_picker_library.dart';
 
 import '../constants/config.dart';
-import '../internals/singleton.dart';
 import '../constants/enums.dart';
 import '../delegates/camera_picker_text_delegate.dart';
 import '../internals/methods.dart';
+import '../internals/singleton.dart';
 import '../widgets/camera_focus_point.dart';
 import '../widgets/camera_picker.dart';
 import '../widgets/camera_picker_viewer.dart';
@@ -926,7 +926,12 @@ class CameraPickerState extends State<CameraPicker>
         viewType: CameraPickerViewType.image,
       );
       if (entity != null) {
-        Navigator.of(context).pop(entity);
+        if (pickerConfig.onPicked case final onPicked?) {
+          await controller.resumePreview();
+          onPicked(entity);
+        } else {
+          Navigator.of(context).pop(entity);
+        }
         return;
       }
       wrapControllerMethod<void>(
@@ -1056,7 +1061,12 @@ class CameraPickerState extends State<CameraPicker>
         viewType: CameraPickerViewType.video,
       );
       if (entity != null) {
-        Navigator.of(context).pop(entity);
+        if (pickerConfig.onPicked case final onPicked?) {
+          await controller.resumePreview();
+          onPicked(entity);
+        } else {
+          Navigator.of(context).pop(entity);
+        }
       } else {
         await controller.resumePreview();
       }

--- a/lib/src/states/camera_picker_state.dart
+++ b/lib/src/states/camera_picker_state.dart
@@ -927,12 +927,10 @@ class CameraPickerState extends State<CameraPicker>
       );
       if (entity != null) {
         if (pickerConfig.onPickConfirmed case final onPickConfirmed?) {
-          await controller.resumePreview();
           onPickConfirmed(entity);
         } else {
-          Navigator.of(context).pop(entity);
+          return Navigator.of(context).pop(entity);
         }
-        return;
       }
       wrapControllerMethod<void>(
         'setFocusMode',


### PR DESCRIPTION
### Context
Currently, when a picture or video is taken using the camera, the AssetEntity is retrieved via:
```
final assetEntity = await pickFromCamera(context);
```
This is achieved by calling `Navigator.of(context).pop(entity);`, which returns the `AssetEntity` to the previous screen.

However, this approach has a limitation when the `CameraPicker` widget is used in a scenario where it doesn't trigger a pop event, such as when the widget is part of a tab or a persistent page in a navigation stack. In these cases, there is no straightforward way to retrieve the captured `AssetEntity`.

### Changes
- Introduced a custom `onPicked` callback that directly provides the generated AssetEntity without relying on the `Navigator.of(context).pop(entity);`.