### PR TITLE
🐛 Predicate the flash mode correctly when retrying the initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ See the [Migration Guide](guides/migration_guide.md) for breaking changes betwee
 
 - Allows `sensor_plus` v6.
 
+### Fixes
+
+- Predicate the flash mode correctly when retrying the initialization.
+
 ## 4.3.4
 
 ### Fixes

--- a/lib/src/states/camera_picker_state.dart
+++ b/lib/src/states/camera_picker_state.dart
@@ -318,18 +318,18 @@ class CameraPickerState extends State<CameraPicker>
   Future<T?> wrapControllerMethod<T>(
     String key,
     Future<T> Function() method, {
-    CameraDescription? description,
+    CameraDescription? camera,
     VoidCallback? onError,
     T? fallback,
   }) async {
-    description ??= currentCamera;
-    if (invalidControllerMethods[description]!.contains(key)) {
+    camera ??= currentCamera;
+    if (invalidControllerMethods[camera]!.contains(key)) {
       return fallback;
     }
     try {
       return await method();
     } catch (e) {
-      invalidControllerMethods[description]!.add(key);
+      invalidControllerMethods[camera]!.add(key);
       onError?.call();
       rethrow;
     }
@@ -407,10 +407,10 @@ class CameraPickerState extends State<CameraPicker>
         index = currentCameraIndex;
       }
       // Initialize the controller with the given resolution preset.
-      final description = cameraDescription ?? cameras[index];
-      invalidControllerMethods[description] ??= <String>{};
+      final camera = cameraDescription ?? cameras[index];
+      invalidControllerMethods[camera] ??= <String>{};
       final CameraController newController = CameraController(
-        description,
+        camera,
         pickerConfig.resolutionPreset,
         enableAudio: enableAudio,
         imageFormatGroup: pickerConfig.imageFormatGroup,
@@ -440,37 +440,37 @@ class CameraPickerState extends State<CameraPicker>
             wrapControllerMethod(
               'getExposureOffsetStepSize',
               () => newController.getExposureOffsetStepSize(),
-              description: description,
+              camera: camera,
               fallback: exposureStep,
             ).then((value) => exposureStep = value!),
             wrapControllerMethod(
               'getMaxExposureOffset',
               () => newController.getMaxExposureOffset(),
-              description: description,
+              camera: camera,
               fallback: maxAvailableExposureOffset,
             ).then((value) => maxAvailableExposureOffset = value!),
             wrapControllerMethod(
               'getMinExposureOffset',
               () => newController.getMinExposureOffset(),
-              description: description,
+              camera: camera,
               fallback: minAvailableExposureOffset,
             ).then((value) => minAvailableExposureOffset = value!),
             wrapControllerMethod(
               'getMaxZoomLevel',
               () => newController.getMaxZoomLevel(),
-              description: description,
+              camera: camera,
               fallback: maxAvailableZoom,
             ).then((value) => maxAvailableZoom = value!),
             wrapControllerMethod(
               'getMinZoomLevel',
               () => newController.getMinZoomLevel(),
-              description: description,
+              camera: camera,
               fallback: minAvailableZoom,
             ).then((value) => minAvailableZoom = value!),
             wrapControllerMethod(
               'getMinZoomLevel',
               () => newController.getMinZoomLevel(),
-              description: description,
+              camera: camera,
               fallback: minAvailableZoom,
             ).then((value) => minAvailableZoom = value!),
             if (pickerConfig.lockCaptureOrientation != null)
@@ -479,24 +479,24 @@ class CameraPickerState extends State<CameraPicker>
                 () => newController.lockCaptureOrientation(
                   pickerConfig.lockCaptureOrientation,
                 ),
-                description: description,
+                camera: camera,
               ),
             // Do not set flash modes for the front camera.
-            Future(() async {
-              final flashMode = pickerConfig.preferredFlashMode;
-              if (validFlashModes[description]?.contains(flashMode) != false &&
-                  description.lensDirection != CameraLensDirection.front &&
-                  flashMode != FlashMode.auto) {
-                return wrapControllerMethod<void>(
-                  'setFlashMode',
-                  () => throw 'Hey',
-                  description: description,
-                  onError: () {
-                    validFlashModes[description]?.remove(flashMode);
-                  },
-                );
-              }
-            }),
+            if (camera.lensDirection != CameraLensDirection.front)
+              Future(() async {
+                final flashMode = pickerConfig.preferredFlashMode;
+                if (flashMode != FlashMode.auto &&
+                    validFlashModes[camera]?.contains(flashMode) != false) {
+                  return wrapControllerMethod<void>(
+                    'setFlashMode',
+                    () => newController.setFlashMode(flashMode),
+                    camera: camera,
+                    onError: () {
+                      validFlashModes[camera]?.remove(flashMode);
+                    },
+                  );
+                }
+              }),
           ],
           eagerError: false,
         );

--- a/lib/src/states/camera_picker_state.dart
+++ b/lib/src/states/camera_picker_state.dart
@@ -482,20 +482,21 @@ class CameraPickerState extends State<CameraPicker>
                 description: description,
               ),
             // Do not set flash modes for the front camera.
-            if (description.lensDirection != CameraLensDirection.front &&
-                pickerConfig.preferredFlashMode != FlashMode.auto)
-              wrapControllerMethod<void>(
-                'setFlashMode',
-                () => newController.setFlashMode(
-                  pickerConfig.preferredFlashMode,
-                ),
-                description: description,
-                onError: () {
-                  validFlashModes[description]?.remove(
-                    pickerConfig.preferredFlashMode,
-                  );
-                },
-              ),
+            Future(() async {
+              final flashMode = pickerConfig.preferredFlashMode;
+              if (validFlashModes[description]?.contains(flashMode) != false &&
+                  description.lensDirection != CameraLensDirection.front &&
+                  flashMode != FlashMode.auto) {
+                return wrapControllerMethod<void>(
+                  'setFlashMode',
+                  () => throw 'Hey',
+                  description: description,
+                  onError: () {
+                    validFlashModes[description]?.remove(flashMode);
+                  },
+                );
+              }
+            }),
           ],
           eagerError: false,
         );


### PR DESCRIPTION
Resolves https://github.com/fluttercandies/flutter_wechat_camera_picker/issues/213#issuecomment-2437115670