### PR TITLE
fix(camera_picker): 为相机闪光模式选择添加超时处理

### DIFF
--- a/lib/src/states/camera_picker_state.dart
+++ b/lib/src/states/camera_picker_state.dart
@@ -517,7 +517,14 @@ class CameraPickerState extends State<CameraPicker>
                     },
                   );
                 }
-              }),
+              }).timeout(
+                const Duration(milliseconds: 250),
+                onTimeout: () {
+                  validFlashModes[camera]
+                      ?.remove(pickerConfig.preferredFlashMode);
+                  return;
+                },
+              ),
           ],
           eagerError: false,
         );


### PR DESCRIPTION
在相机闪光模式选择逻辑中，添加了250毫秒的超时处理，以防止在某些情况下操作卡死。当超时发生时，移除无效的闪光模式，确保用户界面保持响应。